### PR TITLE
Remove some warnings

### DIFF
--- a/cmd/impala/main.go
+++ b/cmd/impala/main.go
@@ -6,7 +6,7 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"os/signal"
@@ -61,10 +61,8 @@ func main() {
 	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 
 	go func() {
-		select {
-		case <-sig:
-			cancel()
-		}
+		<-sig
+		cancel()
 	}()
 
 	if timeout != 0 {
@@ -82,7 +80,7 @@ func main() {
 	}
 
 	if stdinstat.Mode()&os.ModeNamedPipe != 0 {
-		bytes, err := ioutil.ReadAll(os.Stdin)
+		bytes, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -162,16 +160,5 @@ func query(ctx context.Context, opts *impala.Options, query string) error {
 		return err
 	}
 	fmt.Printf("Fetch %d rows(s) in %.2fs\n", results, time.Duration(time.Since(startTime)).Seconds())
-	return nil
-}
-
-func exec(ctx context.Context, db *sql.DB, query string) error {
-	res, err := db.ExecContext(ctx, query)
-	if err != nil {
-		return err
-	}
-
-	log.Print(res)
-	fmt.Print("The operation has no results.\n")
 	return nil
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -1,7 +1,7 @@
 package impala
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 )
 
@@ -12,35 +12,35 @@ func TestParseURI(t *testing.T) {
 	}{
 		{
 			"impala://localhost",
-			Options{Host: "localhost", Port: "21050", BatchSize: 1024, BufferSize: 4096, LogOut: ioutil.Discard},
+			Options{Host: "localhost", Port: "21050", BatchSize: 1024, BufferSize: 4096, LogOut: io.Discard},
 		},
 		{
 			"impala://localhost:21000",
-			Options{Host: "localhost", Port: "21000", BatchSize: 1024, BufferSize: 4096, LogOut: ioutil.Discard},
+			Options{Host: "localhost", Port: "21000", BatchSize: 1024, BufferSize: 4096, LogOut: io.Discard},
 		},
 		{
 			"impala://admin@localhost",
-			Options{Host: "localhost", Port: "21050", Username: "admin", BatchSize: 1024, BufferSize: 4096, LogOut: ioutil.Discard},
+			Options{Host: "localhost", Port: "21050", Username: "admin", BatchSize: 1024, BufferSize: 4096, LogOut: io.Discard},
 		},
 		{
 			"impala://admin:password@localhost",
-			Options{Host: "localhost", Port: "21050", Username: "admin", Password: "password", BatchSize: 1024, BufferSize: 4096, LogOut: ioutil.Discard},
+			Options{Host: "localhost", Port: "21050", Username: "admin", Password: "password", BatchSize: 1024, BufferSize: 4096, LogOut: io.Discard},
 		},
 		{
 			"impala://admin:p%40ssw0rd@localhost",
-			Options{Host: "localhost", Port: "21050", Username: "admin", Password: "p@ssw0rd", BatchSize: 1024, BufferSize: 4096, LogOut: ioutil.Discard},
+			Options{Host: "localhost", Port: "21050", Username: "admin", Password: "p@ssw0rd", BatchSize: 1024, BufferSize: 4096, LogOut: io.Discard},
 		},
 		{
 			"impala://admin:p%40ssw0rd@localhost?auth=ldap",
-			Options{Host: "localhost", Port: "21050", Username: "admin", Password: "p@ssw0rd", UseLDAP: true, BatchSize: 1024, BufferSize: 4096, LogOut: ioutil.Discard},
+			Options{Host: "localhost", Port: "21050", Username: "admin", Password: "p@ssw0rd", UseLDAP: true, BatchSize: 1024, BufferSize: 4096, LogOut: io.Discard},
 		},
 		{
 			"impala://localhost?tls=true&ca-cert=/etc/ca.crt",
-			Options{Host: "localhost", Port: "21050", UseTLS: true, CACertPath: "/etc/ca.crt", BatchSize: 1024, BufferSize: 4096, LogOut: ioutil.Discard},
+			Options{Host: "localhost", Port: "21050", UseTLS: true, CACertPath: "/etc/ca.crt", BatchSize: 1024, BufferSize: 4096, LogOut: io.Discard},
 		},
 		{
 			"impala://localhost?batch-size=2048&buffer-size=2048",
-			Options{Host: "localhost", Port: "21050", BatchSize: 2048, BufferSize: 2048, LogOut: ioutil.Discard},
+			Options{Host: "localhost", Port: "21050", BatchSize: 2048, BufferSize: 2048, LogOut: io.Discard},
 		},
 	}
 

--- a/hive/result_set.go
+++ b/hive/result_set.go
@@ -15,9 +15,8 @@ type ResultSet struct {
 	fetchfn func() (*cli_service.TFetchResultsResp, error)
 	schema  *TableSchema
 
-	operation *Operation
-	result    *cli_service.TRowSet
-	more      bool
+	result *cli_service.TRowSet
+	more   bool
 }
 
 // Next ...

--- a/impala.go
+++ b/impala.go
@@ -3,7 +3,6 @@ package impala
 import (
 	"database/sql"
 	"io"
-	"io/ioutil"
 )
 
 func init() {
@@ -30,5 +29,5 @@ type Options struct {
 
 var (
 	// DefaultOptions for impala driver
-	DefaultOptions = Options{BatchSize: 1024, BufferSize: 4096, Port: "21050", LogOut: ioutil.Discard}
+	DefaultOptions = Options{BatchSize: 1024, BufferSize: 4096, Port: "21050", LogOut: io.Discard}
 )

--- a/sasl/transport.go
+++ b/sasl/transport.go
@@ -139,7 +139,10 @@ func (t *TSaslTransport) Flush(ctx context.Context) error {
 	payload = append(payload, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
 	payload = append(payload, in...)
 
-	t.trans.Write(payload)
+	wn, err := t.trans.Write(payload)
+	if err != nil {
+		return fmt.Errorf("sasl: write payload failed after %d bytes while flushing: %w", wn, err)
+	}
 
 	t.wbuf.Reset()
 	return t.trans.Flush(ctx)


### PR DESCRIPTION
Prepare to include golangci-lint in CI pipeline by removing some warnings.
Many of the warning come from the switch go 1.21

Testing Done: go test ./...